### PR TITLE
Bug Fix and changes

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1029,7 +1029,7 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
         }
     }
     // Figure out how many segments for this gcode
-    uint16_t segments = ceilf((gcode->millimeters_of_travel / arc_segment));
+    uint16_t segments = ceilf(gcode->millimeters_of_travel / arc_segment);
 
   //printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
     float theta_per_segment = angular_travel / segments;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1031,7 +1031,7 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
     // Figure out how many segments for this gcode
     uint16_t segments = ceilf((gcode->millimeters_of_travel / arc_segment));
 
-    printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
+  //printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
     float theta_per_segment = angular_travel / segments;
     float linear_per_segment = linear_travel / segments;
 

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1029,7 +1029,7 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
         }
     }
     // Figure out how many segments for this gcode
-    uint16_t segments = floorf((gcode->millimeters_of_travel / arc_segment)+1);
+    uint16_t segments = ceilf((gcode->millimeters_of_travel / arc_segment));
 
     printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
     float theta_per_segment = angular_travel / segments;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -182,7 +182,7 @@ void Robot::load_config()
     this->mm_per_line_segment = THEKERNEL->config->value(mm_per_line_segment_checksum )->by_default(    0.0F)->as_number();
     this->delta_segments_per_second = THEKERNEL->config->value(delta_segments_per_second_checksum )->by_default(0.0f   )->as_number();
     this->mm_per_arc_segment  = THEKERNEL->config->value(mm_per_arc_segment_checksum  )->by_default(    0.5f)->as_number();
-    this->mm_max_arc_error    = THEKERNEL->config->value(mm_max_arc_error             )->by_default(   0.01f)->as_number();
+    this->mm_max_arc_error    = THEKERNEL->config->value(mm_max_arc_error_checksum    )->by_default(   0.01f)->as_number();
     this->arc_correction      = THEKERNEL->config->value(arc_correction_checksum      )->by_default(    5   )->as_number();
 
     this->max_speeds[X_AXIS]  = THEKERNEL->config->value(x_axis_max_speed_checksum    )->by_default(60000.0F)->as_number() / 60.0F;
@@ -1022,15 +1022,16 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
 
     // limit segments by maximum arc error
     float arc_segment = this->mm_per_arc_segment;
-    if (2 * radius > this->mm_max_arc_error) {
+    if ((this->mm_max_arc_error > 0) && (2 * radius > this->mm_max_arc_error)) {
         float min_err_segment = 2 * sqrtf((this->mm_max_arc_error * (2 * radius - this->mm_max_arc_error)));
         if (this->mm_per_arc_segment < min_err_segment) {
             arc_segment = min_err_segment;
         }
     }
     // Figure out how many segments for this gcode
-    uint16_t segments = floorf(gcode->millimeters_of_travel / arc_segment);
+    uint16_t segments = floorf((gcode->millimeters_of_travel / arc_segment)+1);
 
+    printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
     float theta_per_segment = angular_travel / segments;
     float linear_per_segment = linear_travel / segments;
 


### PR DESCRIPTION
Fixed bug on line 185 which was causing values in config file not to load

Added test to mm_max_arc_error > 0 on line 1025 to allow disabling of the new method 

Changed formula to be more accurate on line 1032.  For both methods.  Fix line segment is a maximum segment length, no segments should be longer than specified,  Interpolation method specifies a max arc error, no arc errors should be larger than specified.  This is an extremely minor technicality, but it is how it should be.   It also prevents the possibility of having the result of 0 for this calculation, the minimum calculated result would be a 1 segment.   a zero was possible before, and if segements=0 then line 1035 and 1036 would be dividing by zero

I originally put in a printf statement to output data to the serial port for testing purposes, I am now convinced the calculations are accurate and the best they could be, so I commented out the printf on line 1034  I left it in for now in case anyone else wants to see the test data first hand.   The commented out printf can be removed for the final release.