### PR TITLE
bug fix, changes with arc error, test output

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1031,7 +1031,7 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
     // Figure out how many segments for this gcode
     uint16_t segments = ceilf(gcode->millimeters_of_travel / arc_segment);
 
-    printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
+    //printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
     float theta_per_segment = angular_travel / segments;
     float linear_per_segment = linear_travel / segments;
 

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1029,7 +1029,7 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
         }
     }
     // Figure out how many segments for this gcode
-    uint16_t segments = floorf((gcode->millimeters_of_travel / arc_segment)+1);
+    uint16_t segments = ceilf(gcode->millimeters_of_travel / arc_segment);
 
     printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
     float theta_per_segment = angular_travel / segments;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -182,7 +182,7 @@ void Robot::load_config()
     this->mm_per_line_segment = THEKERNEL->config->value(mm_per_line_segment_checksum )->by_default(    0.0F)->as_number();
     this->delta_segments_per_second = THEKERNEL->config->value(delta_segments_per_second_checksum )->by_default(0.0f   )->as_number();
     this->mm_per_arc_segment  = THEKERNEL->config->value(mm_per_arc_segment_checksum  )->by_default(    0.5f)->as_number();
-    this->mm_max_arc_error    = THEKERNEL->config->value(mm_max_arc_error             )->by_default(   0.01f)->as_number();
+    this->mm_max_arc_error    = THEKERNEL->config->value(mm_max_arc_error_checksum    )->by_default(   0.01f)->as_number();
     this->arc_correction      = THEKERNEL->config->value(arc_correction_checksum      )->by_default(    5   )->as_number();
 
     this->max_speeds[X_AXIS]  = THEKERNEL->config->value(x_axis_max_speed_checksum    )->by_default(60000.0F)->as_number() / 60.0F;
@@ -1022,15 +1022,16 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
 
     // limit segments by maximum arc error
     float arc_segment = this->mm_per_arc_segment;
-    if (2 * radius > this->mm_max_arc_error) {
+    if ((this->mm_max_arc_error > 0) && (2 * radius > this->mm_max_arc_error)) {
         float min_err_segment = 2 * sqrtf((this->mm_max_arc_error * (2 * radius - this->mm_max_arc_error)));
         if (this->mm_per_arc_segment < min_err_segment) {
             arc_segment = min_err_segment;
         }
     }
     // Figure out how many segments for this gcode
-    uint16_t segments = floorf(gcode->millimeters_of_travel / arc_segment);
+    uint16_t segments = floorf((gcode->millimeters_of_travel / arc_segment)+1);
 
+    printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
     float theta_per_segment = angular_travel / segments;
     float linear_per_segment = linear_travel / segments;
 


### PR DESCRIPTION
Fixed a bug on line 185 so mm_max_arc_error now is correctly read in from config file

Changed line 1025 so setting mm_max_arc_error = 0 will disable the new calculation.  
Setting mm_per_arc_segment = 0 will run only new calculation
setting both to other than 0 will use whichever value is larger
both = 0 is invalid

changed formula on line 1032 to more accurately divide segments.  This prevents the error from ever being greater than the specified arc error.  Since it is a MAX error, the error should never be greater than the specified max.  This also fixes the fixed line segment length method, the fixed length given is a MAX line length, the previous formula would produce segments slightly longer, not slightly shorter.  this is a minor point, however the new formula has one major advantage.. the new formula cannot result in a zero.  the minimum it could ever be is 1.  This solves a potential divide by zero error on lines 1035 and 1036.  It not only solves the divide by zero possibility, it is technically correct.

added a printf to output relevant data to serial port for calculation verification testing purposes only
after many many tests, I'm convinced everything is being calculated correctly and the calculations are the best they could be, so I then commented out the printf on line 1034.  This line could be safely removed, however I left it in just in case someone else wants to run their own tests and comparisons.